### PR TITLE
request-Header parameter invaild

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -10,6 +10,7 @@
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ When you use tomago-sdk-java, you should reference project like this:
 <dependency>
     <groupId>com.arxanfintech</groupId>
     <artifactId>tomago-sdk-java</artifactId>
-    <version>1.5.1</version>
+    <version>2.0.1</version>
 </dependency>
 ```
 
@@ -68,16 +68,16 @@ import com.arxanfintech.sdk.tomago.Tomago;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 
-String strdata = "{\"payload\": {\"chaincode_id\": \"mycc\",\"args\": [\"invoke\", \"a\", \"b\", \"1\"]} }";
+String strdata = "{\"payload\": {\"chaincode_id\": \"pubchain-mycc\",\"args\": [\"invoke\", \"a\", \"b\", \"1\"]} }";
 JSONObject jsondata = JSON.parseObject(strdata);
 
-String strheader = "{\"Callback-Url\":\"http://something.com\"}";
+String strheader = "{\"Callback-Url\":\"http://something.com\", \"Channel-Id\":\"pubchain\"}";
 JSONObject jsonheader = JSON.parseObject(strheader);
 
-Client client = new Client();
-client.Address = "IP:PORT"; //YOUR SERVER ADDRESS
-client.ApiKey = "5zt592jTM1524126512"; // API-KEY
-client.CertPath = "/Users/yan/tmp/cert136"; //your_cert_dir
+String address = "127.0.0.1:9143"; //YOUR SERVER ADDRESS
+String api_key = "MitFg-7HM1540973852"; // API-KEY
+String cert_path = "/home/arxan/bass/cert/"; //your_cert_dir
+Client client = new Client(api_key, cert_path, "", "", "", "", address, true, "tomago");
 
 Tomago tomago = new Tomago(client);
        
@@ -93,13 +93,13 @@ import com.alibaba.fastjson.JSONObject;
 String strdata = "{\"payload\": {\"chaincode_id\": \"mycc\",\"args\":[\"query\", \"a\"]} }";
 JSONObject jsondata = JSON.parseObject(strdata);
 
-String strheader = "{\"Callback-Url\":\"http://something.com\"}";
+String strheader = "{\"Callback-Url\":\"http://something.com\", \"Channel-Id\":\"pubchain\"}";
 JSONObject jsonheader = JSON.parseObject(strheader);
 
-Client client = new Client();
-client.Address = "IP:PORT";
-client.ApiKey = "5zt592jTM1524126512";
-client.CertPath = "/Users/yan/tmp/cert136";
+String address = "127.0.0.1:9143"; //YOUR SERVER ADDRESS
+String api_key = "MitFg-7HM1540973852"; // API-KEY
+String cert_path = "/home/arxan/bass/cert/"; //your_cert_dir
+Client client = new Client(api_key, cert_path, "", "", "", "", address, true, "tomago");
 
 Tomago tomago = new Tomago(client);
      
@@ -112,15 +112,15 @@ import com.arxanfintech.sdk.tomago.Tomago;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 
-String id = "test0";
+String id = "df24213a7ffa19c53f506c3dea8544df750905f5325fac8217496b24c5a880e8"; // TransactionId
 
 String strheader = "{\"Callback-Url\":\"http://something.com\"}";
 JSONObject jsonheader = JSON.parseObject(strheader);
 
-Client client = new Client();
-client.Address = "IP:PORT";
-client.ApiKey = "5zt592jTM1524126512";
-client.CertPath = "/Users/yan/tmp/cert136";
+String address = "127.0.0.1:9143"; //YOUR SERVER ADDRESS
+String api_key = "MitFg-7HM1540973852"; // API-KEY
+String cert_path = "/home/arxan/bass/cert/"; //your_cert_dir
+Client client = new Client(api_key, cert_path, "", "", "", "", address, true, "tomago");
 
 Tomago tomago = new Tomago(client);
         

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ import com.arxanfintech.sdk.tomago.Tomago;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 
-String strdata = "{\"payload\": {\"chaincode_id\": \"mycc\",\"args\":[\"query\", \"a\"]} }";
+String strdata = "{\"payload\": {\"chaincode_id\": \"pubchain-mycc\",\"args\":[\"query\", \"a\"]} }";
 JSONObject jsondata = JSON.parseObject(strdata);
 
 String strheader = "{\"Callback-Url\":\"http://something.com\", \"Channel-Id\":\"pubchain\"}";

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.arxanfintech</groupId>
 	<artifactId>tomago-sdk-java</artifactId>
-	<version>1.5.1</version>
+	<version>2.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>java-sdk</name>
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>com.arxanfintech</groupId>
 			<artifactId>java-common</artifactId>
-			<version>1.5.1</version>
+			<version>2.1.1a</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
 		<dependency>

--- a/src/main/java/com/arxanfintech/sdk/tomago/Tomago.java
+++ b/src/main/java/com/arxanfintech/sdk/tomago/Tomago.java
@@ -18,13 +18,11 @@ package com.arxanfintech.sdk.tomago;
 import java.io.FileInputStream;
 import java.util.List;
 import org.apache.http.NameValuePair;
+//import org.omg.CORBA.Request;
 import org.apache.http.Header;
 
 import com.arxanfintech.common.crypto.Crypto;
 import com.arxanfintech.common.rest.*;
-import com.arxanfintech.common.structs.Headers;
-import com.arxanfintech.common.util.JsonUtil;
-import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 
 /**
@@ -38,9 +36,8 @@ public class Tomago {
 
     public Tomago(Client client) {
         this.client = client;
-        String privateKeyPath = client.CertPath + "/users/" + client.ApiKey + "/" + client.ApiKey + ".key";
-        String publicCertPath = client.CertPath + "/tls/tls.cert";
-        ;
+        String privateKeyPath = client.GetCertPath() + "/users/" + client.GetApiKey() + "/" + client.GetApiKey() + ".key";
+        String publicCertPath = client.GetCertPath() + "/tls/tls.cert";
         try {
             this.crypto = new Crypto(new FileInputStream(privateKeyPath), new FileInputStream(publicCertPath));
         } catch (Exception e) {
@@ -54,8 +51,9 @@ public class Tomago {
         request.body = jsonbody;
         request.header = jsonheader;
         request.crypto = crypto;
-        request.url = "http://" + request.client.Address + "/tomago/v2/blockchain/invoke";
+        request.url = "http://" + request.client.GetAddress() + "/tomago/v2/blockchain/invoke";
 
+        System.out.println(request.header.toString());
         Api api = new Api();
         try {
             api.NewHttpClient();
@@ -74,7 +72,7 @@ public class Tomago {
         request.body = jsonbody;
         request.header = jsonheader;
         request.crypto = crypto;
-        request.url = "http://" + request.client.Address + "/tomago/v2/blockchain/query";
+        request.url = "http://" + request.client.GetAddress()+ "/tomago/v2/blockchain/query";
 
         Api api = new Api();
         try {
@@ -93,7 +91,7 @@ public class Tomago {
         request.client = this.client;
         request.header = jsonheader;
         request.crypto = crypto;
-        request.url = "http://" + request.client.Address + "/tomago/v2/blockchain/transaction/" + id;
+        request.url = "http://" + request.client.GetAddress() + "/tomago/v2/blockchain/transaction/" + id;
 
         Api api = new Api();
         try {

--- a/src/test/java/com/arxanfintech/sdk/tomago/TomagoTest.java
+++ b/src/test/java/com/arxanfintech/sdk/tomago/TomagoTest.java
@@ -64,10 +64,10 @@ public class TomagoTest extends TestCase {
         String strheader = "{\"Callback-Url\":\"http://something.com\"}";
         JSONObject jsonheader = JSON.parseObject(strheader);
 
-        Client client = new Client();
-        client.Address = "IP:PORT";
-        client.ApiKey = "5zt592jTM1524126512";
-        client.CertPath = "/Users/yan/tmp/cert136";
+        Client client = new Client("", "", "", "", "", "", "");
+//        client.Address = "IP:PORT";
+//        client.ApiKey = "5zt592jTM1524126512";
+//        client.CertPath = "/Users/yan/tmp/cert136";
 
         Tomago tomago = new Tomago(client);
 
@@ -90,10 +90,7 @@ public class TomagoTest extends TestCase {
         String strheader = "{\"Callback-Url\":\"http://something.com\"}";
         JSONObject jsonheader = JSON.parseObject(strheader);
 
-        Client client = new Client();
-        client.Address = "IP:PORT";
-        client.ApiKey = "5zt592jTM1524126512";
-        client.CertPath = "/Users/yan/tmp/cert136";
+    	Client client = new Client("api-key", "/path/to/cert", "","","","", "127.0.0.1:9143", true, "tomago");
 
         Tomago tomago = new Tomago(client);
 
@@ -115,10 +112,7 @@ public class TomagoTest extends TestCase {
         String strheader = "{\"Callback-Url\":\"http://something.com\"}";
         JSONObject jsonheader = JSON.parseObject(strheader);
 
-        Client client = new Client();
-        client.Address = "IP:PORT";
-        client.ApiKey = "5zt592jTM1524126512";
-        client.CertPath = "/Users/yan/tmp/cert136";
+    	Client client = new Client("api-key", "/path/to/cert", "","","","", "127.0.0.1:9143", true, "tomago");
 
         Tomago tomago = new Tomago(client);
 


### PR DESCRIPTION
1.为解决请求头中添加channel-id参数无效的bug, 升级所依赖的java-common 到v2.1.1a, 这是已经发布的java-common里解决这个问题的最低版本
2. 发布tomago 新版本v2.0.1到maven库